### PR TITLE
The path in the cd command should be in quotation marks.

### DIFF
--- a/shellwrapper.sh
+++ b/shellwrapper.sh
@@ -114,7 +114,7 @@ do
     # As exportshells may navigate through the directories and also will change
     # that for the wrapper, we make sure we land back in our shell files
     # directory after calling the script.
-    cd $SHELL_FILES_DIR_ABSOLUTE
+    cd "$SHELL_FILES_DIR_ABSOLUTE"
   fi
 
 done


### PR DESCRIPTION
If there is a blank in the path, the shellwrapper stops working.
- E. g.: `cd /Volumes/Mac SD/webprojects/nicepage/docroot/` (Won't work)
- E. g.: `cd "/Volumes/Mac SD/webprojects/nicepage/docroot/"` (Will work)
